### PR TITLE
Add F import when torch is available

### DIFF
--- a/src/core/video_decoder.py
+++ b/src/core/video_decoder.py
@@ -12,6 +12,7 @@ from decord import VideoReader, gpu, cpu
 # Try to import torch with error handling
 try:
     import torch
+    import torch.nn.functional as F
     TORCH_AVAILABLE = True
 except ImportError as e:
     logging.warning(f"PyTorch not available: {e}")


### PR DESCRIPTION
## Summary
- import `torch.nn.functional as F` inside `video_decoder`'s torch import block

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6854e442cf48832b823c8a637212cb33