### PR TITLE
Add transparent overlay option

### DIFF
--- a/quick_start.py
+++ b/quick_start.py
@@ -95,7 +95,7 @@ with tab3:
     with col1:
         st.subheader("🎨 Visual")
         fps = st.slider("FPS", 1, 15, 5)
-        overlay_style = st.selectbox("Estilo", ["heatmap", "highlight", "glow", "pulse"])
+        overlay_style = st.selectbox("Estilo", ["heatmap", "highlight", "glow", "pulse", "transparent"])
         overlay_intensity = st.slider("Intensidad", 0.0, 1.0, 0.7, 0.1)
     
     with col2:
@@ -220,6 +220,7 @@ def create_simple_html():
                         <option value="highlight">✨ Highlight</option>
                         <option value="glow">🌟 Glow</option>
                         <option value="pulse">💫 Pulse</option>
+                        <option value="transparent">⚪ Transparent</option>
                     </select>
                 </div>
             </div>

--- a/src/streamlit_demo.py
+++ b/src/streamlit_demo.py
@@ -82,7 +82,7 @@ with tab3:
     with col1:
         st.subheader("🎨 Visual")
         fps = st.slider("FPS", 1, 15, 5)
-        overlay_style = st.selectbox("Estilo", ["heatmap", "highlight", "glow", "pulse"])
+        overlay_style = st.selectbox("Estilo", ["heatmap", "highlight", "glow", "pulse", "transparent"])
         overlay_intensity = st.slider("Intensidad", 0.0, 1.0, 0.7, 0.1)
     
     with col2:


### PR DESCRIPTION
## Summary
- add `transparent` to overlay style select boxes in Streamlit demo
- update quick start code and HTML to include the transparent style

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6854e5b72b7c832bbc2d8236b11a784f